### PR TITLE
@starsirius Specify radix in parseInt to guarantee predictable behavior.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@
   function hhmmToSecondsSinceMidnight(hhmm) {
     var h = hhmm.split(':')[0]
       , m = hhmm.split(':')[1];
-    return parseInt(h) * 60 + parseInt(m);
+    return parseInt(h, 10) * 60 + parseInt(m, 10);
   }
 
   function secondsSinceMidnightToHhmm(seconds) {


### PR DESCRIPTION
Specify radix in `parseInt` to guarantee predictable behavior. Otherwise,

``` javascript
parseInt('08');     // 0
parseInt('08', 10); // 8
```

in some implementations.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
