### PR TITLE
Fix empty last time slot when there are many calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Features
 
 * [#33](https://github.com/artsy/day-schedule-selector/pull/33): Add Danger; add mocha, chai, and sinon to dev dependencies - [@starsirius](https://github.com/starsirius).
+* [#35](https://github.com/artsy/day-schedule-selector/pull/35): Fix empty last time slot when there are many calendars  - [@adelriosantiago](https://github.com/adelriosantiago).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### Features
 
 * [#33](https://github.com/artsy/day-schedule-selector/pull/33): Add Danger; add mocha, chai, and sinon to dev dependencies - [@starsirius](https://github.com/starsirius).
-* [#35](https://github.com/artsy/day-schedule-selector/pull/35): Fix empty last time slot when there are many calendars  - [@adelriosantiago](https://github.com/adelriosantiago).
 
 #### Fixes
 
+* [#35](https://github.com/artsy/day-schedule-selector/pull/35): Fix empty last time slot when there are many calendars  - [@adelriosantiago](https://github.com/adelriosantiago).

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@
         }
 
         // End of selection (I am the last one :) .)
-        if (isSlotSelected($(this)) && !!start && $(this).is(".time-slot[data-day='" + v + "']:last")) {
+        if (isSlotSelected($(this)) && !!start && $(this).is($(this).closest('tbody').find(".time-slot[data-day='" + v + "']:last"))) {
           end = secondsSinceMidnightToHhmm(
             hhmmToSecondsSinceMidnight($(this).data('time')) + plugin.options.interval * 60);
         }


### PR DESCRIPTION
This fixes the empty range serialization when selecting the last timeslot and there are more than 1 calendars or many .time-slot classes.