### PR TITLE
Scroll browser window when selecting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@
       , $slots;
 
     this.$el.on('click', '.time-slot', function () {
+      var bodyElement = $('html, body');
       var day = $(this).data('day');
       if (!plugin.isSelecting()) {  // if we are not in selecting mode
         if (isSlotSelected($(this))) { plugin.deselect($(this)); }
@@ -109,10 +110,40 @@
           $(this).attr('data-selecting', 'selecting');
           plugin.$el.find('.time-slot').attr('data-disabled', 'disabled');
           plugin.$el.find('.time-slot[data-day="' + day + '"]').removeAttr('data-disabled');
+
+          bodyElement.mouseleave(function(event) {
+              console.log('mouse leave: '+ event.pageX + ' ' + event.pageY);
+
+              var leftPageY = event.pageY;
+              var scrollTop = bodyElement.scrollTop();
+              var windowHeight = $(window).height();
+              var pageCenter = scrollTop + (windowHeight / 2);
+              var isScrollDown = (leftPageY > pageCenter);
+              var scrollDelta = isScrollDown ? 5 : -5;
+              var scrollInterval = 50;
+              var scrollTarget = leftPageY - (isScrollDown ? windowHeight : 0);
+
+              var _scrollDown = function() {
+                  scrollTarget += scrollDelta;
+                  bodyElement.scrollTop(scrollTarget);
+              };
+
+              //_scrollDown();
+              var timerId = setInterval(_scrollDown, scrollInterval);
+
+              bodyElement.mouseenter(function() {
+                  console.log('mouse enter');
+                  clearInterval(timerId);
+                  bodyElement.off('mouseenter');
+              });
+          });
         }
       } else {  // if we are in selecting mode
         if (day == plugin.$selectingStart.data('day')) {  // if clicking on the same day column
           // then end of selection
+          bodyElement.off('mouseleave');
+          bodyElement.off('mouseenter');
+
           plugin.$el.find('.time-slot[data-day="' + day + '"]').filter('[data-selecting]')
             .attr('data-selected', 'selected').removeAttr('data-selecting');
           plugin.$el.find('.time-slot').removeAttr('data-disabled');

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@
                   bodyElement.scrollTop(scrollTarget);
               };
 
-              //_scrollDown();
+              _scrollDown();
               var timerId = setInterval(_scrollDown, scrollInterval);
 
               bodyElement.mouseenter(function() {


### PR DESCRIPTION
I have a use case that requires a schedule table that is taller than some browser windows, and in user testing it seemed to be expected that the browser would scroll vertically when the mouse exits the window while selecting a range.

This is a fairly rough implementation, but it does work. If you see value in it, I can refine it a bit more and maybe make it configurable through options. Thoughts?